### PR TITLE
Fix build with Qt 5.11_beta3 (dropping qt5_use_modules)

### DIFF
--- a/src/libqtdbusmock/CMakeLists.txt
+++ b/src/libqtdbusmock/CMakeLists.txt
@@ -191,11 +191,11 @@ add_library(
 	${QTDBUSMOCK_SRC}
 )
 
-qt5_use_modules(
-	qtdbusmock
-	Core
-	DBus
-	Test
+target_link_libraries(
+    qtdbusmock
+    Qt5::Core
+    Qt5::DBus
+    Qt5::Test
 )
 
 target_link_libraries(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,11 +18,11 @@ add_executable(
 	${UNIT_TESTS_SRC}
 )
 
-qt5_use_modules(
-	unit-tests
-	Core
-	DBus
-	Test
+target_link_libraries(
+    unit-tests
+    Qt5::Core
+    Qt5::DBus
+    Qt5::Test
 )
 
 target_link_libraries(


### PR DESCRIPTION
Closes #1 

Tested on Arch GNU/Linux.